### PR TITLE
Add delimited strings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,4 @@
 {:extra-paths ["resources"]
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}
-        com.tomgibara.bits/bits {:mvn/version "2.1.0"}}}
+        com.tomgibara.bits/bits {:mvn/version "2.1.0"}
+        net.cgrand/xforms {:mvn/version "0.18.2"}}}

--- a/src/mfiano/parsley/data_types.clj
+++ b/src/mfiano/parsley/data_types.clj
@@ -3,7 +3,7 @@
   (:require [mfiano.parsley.transformers :as tr]
             [net.cgrand.xforms :as xf])
   (:import [java.io InputStreamReader]
-           [com.tomgibara.bits Bits BitReader BitStore]))
+           [com.tomgibara.bits Bits BitReader BitStore EndOfBitStreamException]))
 
 (defn- convert-string-encoding
   [{:keys [encoding endian]}]
@@ -74,7 +74,7 @@
               (lazy-seq (try (cons (unchecked-byte (.read reader 8))
                                    (f (and remaining
                                            (- remaining 8))))
-                             (catch Exception e
+                             (catch EndOfBitStreamException e
                                nil)))))]
     (f size)))
 

--- a/src/mfiano/parsley/data_types.clj
+++ b/src/mfiano/parsley/data_types.clj
@@ -26,13 +26,12 @@
   (let [rf (xf (fn [_ v] v))
         f (fn f [coll]
             (lazy-seq (loop [coll coll]
-                        (if (seq coll)
+                        (when (seq coll)
                           (if-let [res (rf nil (first coll))]
                             (if (reduced? res)
                               (cons @res nil)
                               (cons res (f (rest coll))))
-                            (recur (rest coll)))
-                          nil))))]
+                            (recur (rest coll)))))))]
     (f coll)))
 
 (defn- get-delimited-string-bytes
@@ -70,14 +69,13 @@
 (defn- bytes-seq
   [^BitReader reader {:keys [size]}]
   (letfn [(f [remaining]
-            (if (or (nil? remaining)
-                    (pos? remaining))
+            (when (or (nil? remaining)
+                      (pos? remaining))
               (lazy-seq (try (cons (unchecked-byte (.read reader 8))
                                    (f (and remaining
                                            (- remaining 8))))
                              (catch Exception e
-                               nil)))
-              nil))]
+                               nil)))))]
     (f size)))
 
 (defn read-string

--- a/src/mfiano/parsley/data_types.clj
+++ b/src/mfiano/parsley/data_types.clj
@@ -21,7 +21,7 @@
   (vec (.getBytes ^String s
                   ^String (convert-string-encoding options))))
 
-(defn- my-sequence
+(defn- sequence*
   [xf coll]
   (let [rf (xf (fn [_ v] v))
         f (fn f [coll]
@@ -41,7 +41,7 @@
                  (map-indexed vector)
                  (filter #(= (second %) delimiter-bytes))
                  (map first))
-        delimiter-index (first (my-sequence xf bytes))
+        delimiter-index (first (sequence* xf bytes))
         new-bytes (take (or delimiter-index 0)
                         bytes)]
     (if (nil? delimiter-index)

--- a/src/mfiano/parsley/data_types.clj
+++ b/src/mfiano/parsley/data_types.clj
@@ -45,7 +45,9 @@
         delimiter-index (first (my-sequence xf bytes))
         new-bytes (take (or delimiter-index 0)
                         bytes)]
-    (byte-array new-bytes)))
+    (if (nil? delimiter-index)
+      (byte-array bytes)
+      (byte-array new-bytes))))
 
 (defn- read-boolean
   [^BitReader reader]
@@ -74,7 +76,6 @@
                                    (f (and remaining
                                            (- remaining 8))))
                              (catch Exception e
-                               (println (clojure.stacktrace/print-throwable e))
                                nil)))
               nil))]
     (f size)))
@@ -82,7 +83,7 @@
 (defn read-string
   [^BitReader reader {:keys [delimiter] :as options}]
   (let [loc (.getPosition reader)
-        bytes (bytes-seq reader (assoc options :endian :be))
+        bytes (bytes-seq reader options)
         ret (String. ^bytes (get-delimited-string-bytes bytes options)
                      ^String (convert-string-encoding options))]
     (.setPosition reader (+ loc (count ret) (count delimiter)))

--- a/src/mfiano/parsley/example.clj
+++ b/src/mfiano/parsley/example.clj
@@ -12,9 +12,7 @@
 (defn doit
   [spec path]
   (let [file-map (io/open-file spec path)]
-    [(d/read :string file-map :size 32)
-     (d/read :bits file-map :size 1)
-     (d/read :bits file-map :size 7)
+    [(d/read :string file-map :delimiter "\0")
      (d/read :uint file-map :size 24)
      (d/read :uint file-map :size 16)
      (d/read :uint file-map :size 16)
@@ -25,3 +23,6 @@
      (d/read :bits file-map :size 5)
      (d/read :bits file-map :size 36)
      (tr/bytes->hex-string (d/read :bytes file-map :size 128))]))
+
+(comment
+  (doit spec "test.flac"))


### PR DESCRIPTION
Adds a way to use delimited strings when parsing by using a lazy-seq to traverse the bit stream, before setting the position of the reader back to the appropriate spot to ensure chunking doesn't break anything.

As a side note, this will require additional error handling in the case that it attempts to scan off the end of the file.